### PR TITLE
feat(roomtype): delete room type

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
@@ -10,10 +10,8 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -21,11 +19,12 @@ import java.net.URI;
 @RestController
 @RequestMapping("/room-types")
 @AllArgsConstructor
+@SecurityRequirement(name = "bearer-key")
+@PreAuthorize("hasRole('ADMIN')")
 public class RoomTypeController {
 
     private final IRoomTypeService roomTypeService;
 
-    @SecurityRequirement(name = "bearer-key")
     @PostMapping
     @Transactional
     public ResponseEntity<DataResponse<RoomTypeResponseDTO>> createRoomType(
@@ -40,4 +39,12 @@ public class RoomTypeController {
         );
         return ResponseEntity.created(url).body(response);
     }
+
+    @DeleteMapping("/{id}")
+    @Transactional
+    public ResponseEntity<Void> deleteRoomType(@PathVariable Long id) {
+        roomTypeService.deleteRoomType(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/model/RoomType.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/model/RoomType.java
@@ -22,4 +22,8 @@ public class RoomType {
     public RoomType(RoomTypeRegisterDTO roomTypeDto) {
         this.name = roomTypeDto.name();
     }
+
+    public void deactive() {
+        this.enabled = false;
+    }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/repository/IRoomTypeRepository.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/repository/IRoomTypeRepository.java
@@ -2,8 +2,19 @@ package com.example.skilllinkbackend.features.roomtype.repository;
 
 import com.example.skilllinkbackend.features.roomtype.model.RoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface IRoomTypeRepository extends JpaRepository<RoomType, Long> {
+
+    @Query("""
+            SELECT r
+            FROM RoomType r
+            WHERE r.enabled = true
+            AND r.id = :id
+            """)
+    Optional<RoomType> findById(Long id);
 }

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/service/IRoomTypeService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/service/IRoomTypeService.java
@@ -5,4 +5,6 @@ import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeResponseDTO;
 
 public interface IRoomTypeService {
     RoomTypeResponseDTO createRoomType(RoomTypeRegisterDTO roomTypeDto);
+
+    void deleteRoomType(Long id);
 }

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/service/RoomTypeService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/service/RoomTypeService.java
@@ -1,5 +1,6 @@
 package com.example.skilllinkbackend.features.roomtype.service;
 
+import com.example.skilllinkbackend.config.exceptions.NotFoundException;
 import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeRegisterDTO;
 import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeResponseDTO;
 import com.example.skilllinkbackend.features.roomtype.model.RoomType;
@@ -20,5 +21,12 @@ public class RoomTypeService implements IRoomTypeService{
         RoomType roomType = new RoomType(roomTypeDto);
         roomTypeRepository.save(roomType);
         return new RoomTypeResponseDTO(roomType);
+    }
+
+    @Override
+    public void deleteRoomType(Long id) {
+        RoomType roomType = roomTypeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de habitación no encontrada"));
+        roomType.deactive();
     }
 }


### PR DESCRIPTION
## 🚀 Feature: Endpoint para eliminar un tipo de habitación (borrado lógico)

### 📌 Descripción

Se implementó el endpoint para permitir la **eliminación lógica** de un tipo de habitación existente. Esta funcionalidad pertenece al módulo `RoomType` y respeta la arquitectura por capas del proyecto. El borrado lógico garantiza que los datos no se eliminan físicamente de la base de datos, sino que se marcan como inactivos mediante una bandera (`enabled`).

### 📂 Archivos modificados

- `RoomTypeController.java`  
  ➤ Se agregó un nuevo endpoint `@DeleteMapping("/{id}")` para eliminar lógicamente un tipo de habitación por su ID.

- `RoomTypeService.java`  
  ➤ Implementación del método `deleteRoomType(Long id)`, que busca el tipo de habitación y actualiza su estado a eliminado (`enabled= false`).

- `IRoomTypeService.java`  
  ➤ Se agregó la firma del método `deleteRoomType`.

- `IRoomTypeRepository.java`  
  ➤ Interfaz de JPA usada para recuperar y persistir el estado del tipo de habitación.

- `RoomType.java`  
  ➤ Se agregó el campo `enabled`.

### ✅ Resultado esperado

El endpoint `DELETE /api/room-types/{id}` marca un tipo de habitación como eliminado (`enabled= false`) sin eliminarlo físicamente.  
Se espera una respuesta:

- `204 No Content` si la eliminación lógica fue exitosa.  
- `404 Not Found` si el tipo de habitación no existe o ya estaba marcado como eliminado.

