### PR TITLE
feat(roomtype): find by id

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
@@ -65,4 +65,9 @@ public class RoomTypeController {
         response.put("hasPrevious", roomTypePage.hasPrevious());
         return response;
     }
+
+    @GetMapping("/{id}")
+    public RoomTypeResponseDTO findById(@PathVariable Long id) {
+        return roomTypeService.findById(id);
+    }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/service/IRoomTypeService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/service/IRoomTypeService.java
@@ -11,4 +11,6 @@ public interface IRoomTypeService {
     void deleteRoomType(Long id);
 
     Page<RoomTypeResponseDTO> findAll(Pageable pagination);
+
+    RoomTypeResponseDTO findById(Long id);
 }

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/service/RoomTypeService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/service/RoomTypeService.java
@@ -28,12 +28,19 @@ public class RoomTypeService implements IRoomTypeService {
     @Override
     public void deleteRoomType(Long id) {
         RoomType roomType = roomTypeRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Tipo de habitación no encontrada"));
+                .orElseThrow(() -> new NotFoundException("Tipo de habitación no encontrado"));
         roomType.deactive();
     }
 
     @Override
     public Page<RoomTypeResponseDTO> findAll(Pageable pagination) {
         return roomTypeRepository.findAll(pagination).map(RoomTypeResponseDTO::new);
+    }
+
+    @Override
+    public RoomTypeResponseDTO findById(Long id) {
+        RoomType roomType = roomTypeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de habitación no encontrado"));
+        return new RoomTypeResponseDTO(roomType);
     }
 }


### PR DESCRIPTION
## 🔍 Feature: Endpoint para obtener un tipo de habitación por ID (solo si está habilitado)

### 📌 Descripción

Se implementó el endpoint que permite **buscar un tipo de habitación por su ID**, siempre que el registro esté habilitado (`enabled = true`).  
Este cambio permite acceder a información específica de un tipo de habitación sin exponer datos inactivos.

### 📂 Archivos modificados

- `RoomTypeController.java`  
  ➤ Se añadió un endpoint `@GetMapping("/{id}")` que recibe un ID como parámetro y retorna el tipo de habitación correspondiente, si está habilitado.

- `RoomTypeService.java`  
  ➤ Se implementó la lógica en el método `findById(Long id)` que valida el estado del campo `enabled`.

- `IRoomTypeService.java`  
  ➤ Se agregó la firma del método `findById`.

### ✅ Resultado esperado

El endpoint `GET /api/room-types/{id}` devuelve los datos del tipo de habitación con el ID especificado **solo si está habilitado** (`enabled = true`).

- `200 OK`: si se encuentra y está habilitado  
- `404 Not Found`: si no existe o está deshabilitado

