### PR TITLE
docs(room-type): add SpringDoc annotations to controller

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
@@ -5,7 +5,12 @@ import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeRegisterDTO;
 import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeResponseDTO;
 import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeUpdateDTO;
 import com.example.skilllinkbackend.features.roomtype.service.IRoomTypeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -27,10 +32,19 @@ import java.util.Map;
 @AllArgsConstructor
 @SecurityRequirement(name = "bearer-key")
 @PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Tipos de habitaciones", description = "Operaciones relacionadas con la gestión de tipos de habitaciones")
 public class RoomTypeController {
 
     private final IRoomTypeService roomTypeService;
 
+    @Operation(
+            summary = "Crear una nueva categoría",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Tipo de habitación creado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     public ResponseEntity<DataResponse<RoomTypeResponseDTO>> createRoomType(
@@ -46,6 +60,14 @@ public class RoomTypeController {
         return ResponseEntity.created(url).body(response);
     }
 
+    @Operation(
+            summary = "Eliminar un tipo de habitación por ID",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Tipo de habitación eliminado exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Tipo de habitación no encontrado", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteRoomType(@PathVariable Long id) {
@@ -53,6 +75,19 @@ public class RoomTypeController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(
+            summary = "Listar tipos de habitaciones con paginación",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo para ordenar (ej: name,asc)", example = "name,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de tipos de habitaciones")
+            }
+    )
+    @PreAuthorize("hasAnyRole('ADMIN', 'RECEPTION')")
     @GetMapping
     public Map<String, Object> findAll(@PageableDefault(size = 10, sort = "name") Pageable pagination) {
         Page<RoomTypeResponseDTO> roomTypePage = roomTypeService.findAll(pagination);
@@ -67,11 +102,29 @@ public class RoomTypeController {
         return response;
     }
 
+    @Operation(
+            summary = "Obtener un tipo de habitación por su ID",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Tipo de habitación encontrado"),
+                    @ApiResponse(responseCode = "404", description = "Tipo de habitación no encontrado", content = @Content)
+            }
+    )
+    @PreAuthorize("hasAnyRole('ADMIN', 'RECEPTION')")
     @GetMapping("/{id}")
     public RoomTypeResponseDTO findById(@PathVariable Long id) {
         return roomTypeService.findById(id);
     }
 
+    @Operation(
+            summary = "Actualizar un tipo de habitación existente",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Tipo de habitación actualizada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Tipo de habitación no encontrada", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public RoomTypeResponseDTO updateRoomType(


### PR DESCRIPTION
## 📄 Documentar API del módulo de tipos de habitaciones

### ✨ Descripción

Se agregaron anotaciones de **SpringDoc (OpenAPI)** al controlador `RoomTypeController` con el objetivo de documentar los endpoints del módulo de tipos de habitaciones. Esto permite que herramientas como Swagger UI generen descripciones claras, parámetros esperados y códigos de respuesta para cada operación.

### ✅ Cambios realizados

- Añadidas anotaciones:
  - `@Operation` para describir cada endpoint
  - `@ApiResponse` para documentar posibles respuestas HTTP
  - `@Parameter` para detallar los parámetros de entrada
  - `@SecurityRequirement` para especificar seguridad con token Bearer
- Documentados los siguientes endpoints:
  - `POST /room-types`: creación de tipo de habitación
  - `DELETE /room-types/{id}`: eliminación por ID
  - `GET /room-types`: listado paginado de tipos de habitación
  - `GET /room-types/{id}`: búsqueda de un tipo de habitación por id
  - `UPDATE /room-types/{id}`: actualización de tipos de habitación
- Se especificaron los roles permitidos en cada método (ADMIN, RECEPTION).

### 📂 Archivo modificado

- `src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java`

### 📌 Notas

- Este cambio no afecta la lógica de negocio ni modifica el comportamiento de los endpoints.
- Solo se enfoca en mejorar la documentación generada automáticamente para facilitar el consumo de la API.
