### PR TITLE
feat(room): create endpoint to register new room

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/room/controller/RoomController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/controller/RoomController.java
@@ -1,0 +1,48 @@
+package com.example.skilllinkbackend.features.room.controller;
+
+import com.example.skilllinkbackend.config.responses.DataResponse;
+import com.example.skilllinkbackend.features.room.dto.RoomRegisterDTO;
+import com.example.skilllinkbackend.features.room.dto.RoomResponseDTO;
+import com.example.skilllinkbackend.features.room.service.IRoomService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/rooms")
+@SecurityRequirement(name = "bearer-key")
+@PreAuthorize("hasRole('ADMIN')")
+public class RoomController {
+
+    private final IRoomService roomService;
+
+    public RoomController(IRoomService roomService) {
+        this.roomService = roomService;
+    }
+
+    @PostMapping
+    @Transactional
+    public ResponseEntity<DataResponse<RoomResponseDTO>> createRoom(
+            @RequestBody @Valid RoomRegisterDTO roomRegisterDTO,
+            UriComponentsBuilder uriComponentsBuilder
+    ) {
+        RoomResponseDTO roomResponseDTO = roomService.createRoom(roomRegisterDTO);
+        URI url = uriComponentsBuilder.path("/rooms/{id}").buildAndExpand(roomResponseDTO.id()).toUri();
+        DataResponse<RoomResponseDTO> response = new DataResponse<>(
+                "Habitación creada con éxito",
+                HttpStatus.CREATED.value(),
+                roomResponseDTO
+        );
+        return ResponseEntity.created(url).body(response);
+    }
+}

--- a/src/main/java/com/example/skilllinkbackend/features/room/dto/RoomRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/dto/RoomRegisterDTO.java
@@ -1,0 +1,25 @@
+package com.example.skilllinkbackend.features.room.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record RoomRegisterDTO(
+        @NotNull(message = "El piso no puede ser nulo")
+        @Min(value = 1, message = "El piso debe ser al menos 1")
+        Integer floor,
+
+        @NotNull(message = "El precio no puede ser nulo")
+        @DecimalMin(value = "0.0", inclusive = false, message = "El precio debe ser mayor a 0")
+        BigDecimal price,
+
+        @NotBlank(message = "El número de habitación no puede estar vacío")
+        String number,
+
+        @NotNull(message = "El id del tipo de habitación no puede ser nulo")
+        Long roomTypeId
+) {
+}

--- a/src/main/java/com/example/skilllinkbackend/features/room/dto/RoomResponseDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/dto/RoomResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.skilllinkbackend.features.room.dto;
+
+import com.example.skilllinkbackend.features.room.model.Room;
+import com.example.skilllinkbackend.features.roomtype.dto.RoomTypeResponseDTO;
+
+import java.math.BigDecimal;
+
+public record RoomResponseDTO(
+        Long id,
+        Integer floor,
+        BigDecimal price,
+        boolean available,
+        boolean enabled,
+        String number,
+        RoomTypeResponseDTO roomType
+) {
+    public RoomResponseDTO(Room room) {
+        this(
+                room.getId(),
+                room.getFloor(),
+                room.getPrice(),
+                room.isAvailable(),
+                room.isEnabled(),
+                room.getNumber(),
+                new RoomTypeResponseDTO(room.getType())
+        );
+    }
+}

--- a/src/main/java/com/example/skilllinkbackend/features/room/model/Room.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/model/Room.java
@@ -1,6 +1,7 @@
 package com.example.skilllinkbackend.features.room.model;
 
 import com.example.skilllinkbackend.features.accommodation.model.Accommodation;
+import com.example.skilllinkbackend.features.room.dto.RoomRegisterDTO;
 import com.example.skilllinkbackend.features.roomtype.model.RoomType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
@@ -22,4 +23,10 @@ public class Room extends Accommodation {
     @ManyToOne
     @JoinColumn(name = "room_type_id")
     private RoomType type; // Ej: "SIMPLE", "DOUBLE", etc.
+
+    public Room(RoomRegisterDTO dto) {
+        this.setFloor(dto.floor());
+        this.setPrice(dto.price());
+        this.number = dto.number();
+    }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/room/repository/IRoomRepository.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/repository/IRoomRepository.java
@@ -1,0 +1,9 @@
+package com.example.skilllinkbackend.features.room.repository;
+
+import com.example.skilllinkbackend.features.room.model.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IRoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/com/example/skilllinkbackend/features/room/service/IRoomService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/service/IRoomService.java
@@ -1,0 +1,8 @@
+package com.example.skilllinkbackend.features.room.service;
+
+import com.example.skilllinkbackend.features.room.dto.RoomRegisterDTO;
+import com.example.skilllinkbackend.features.room.dto.RoomResponseDTO;
+
+public interface IRoomService {
+    RoomResponseDTO createRoom(RoomRegisterDTO roomRegisterDTO);
+}

--- a/src/main/java/com/example/skilllinkbackend/features/room/service/RoomService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/service/RoomService.java
@@ -1,0 +1,32 @@
+package com.example.skilllinkbackend.features.room.service;
+
+import com.example.skilllinkbackend.config.exceptions.NotFoundException;
+import com.example.skilllinkbackend.features.room.dto.RoomRegisterDTO;
+import com.example.skilllinkbackend.features.room.dto.RoomResponseDTO;
+import com.example.skilllinkbackend.features.room.model.Room;
+import com.example.skilllinkbackend.features.room.repository.IRoomRepository;
+import com.example.skilllinkbackend.features.roomtype.model.RoomType;
+import com.example.skilllinkbackend.features.roomtype.repository.IRoomTypeRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoomService implements IRoomService {
+
+    private final IRoomRepository roomRepository;
+    private final IRoomTypeRepository roomTypeRepository;
+
+    public RoomService(IRoomRepository roomRepository, IRoomTypeRepository roomTypeRepository) {
+        this.roomRepository = roomRepository;
+        this.roomTypeRepository = roomTypeRepository;
+    }
+
+    @Override
+    public RoomResponseDTO createRoom(RoomRegisterDTO roomRegisterDTO) {
+        Room room = new Room(roomRegisterDTO);
+        RoomType roomType = roomTypeRepository.findById(roomRegisterDTO.roomTypeId())
+                .orElseThrow(() -> new NotFoundException("Tipo de habitación no encontrado"));
+        room.setType(roomType);
+        Room roomDb = roomRepository.save(room);
+        return new RoomResponseDTO(roomDb);
+    }
+}


### PR DESCRIPTION
## ✨ Crear endpoint para registro de habitaciones

### 📝 Descripción

Se implementa el endpoint para registrar una nueva habitación en el sistema. Esta funcionalidad incluye el controlador, los DTOs correspondientes, la lógica de negocio en el servicio, y la persistencia en el repositorio.

### ✅ Cambios realizados

```diff
+ RoomController.java
+ RoomRegisterDTO.java
+ RoomResponseDTO.java
+ IRoomRepository.java
+ IRoomService.java
+ RoomService.java

* RoomController.java
* RoomRegisterDTO.java
* RoomResponseDTO.java
* Room.java
* IRoomRepository.java
* IRoomService.java
* RoomService.java


🔐 Seguridad
El endpoint está protegido para que solo usuarios con el rol ADMIN puedan acceder.
Se utiliza una anotación como:

@PreAuthorize("hasRole('ADMIN')")

Esto asegura que únicamente administradores puedan registrar nuevas habitaciones.

📲 Endpoint agregado
POST /api/rooms – Crea una nueva habitación con los datos proporcionados.

📌 Notas adicionales
El campo roomTypeId debe ser válido y corresponder a un tipo de habitación existente.

Se aplican validaciones al DTO para garantizar la integridad de los datos.

La respuesta retorna la información de la habitación registrada en un RoomResponseDTO.
