### PR TITLE
feat(department): delete

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
@@ -10,10 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -43,5 +40,12 @@ public class DepartmentController {
                 departmentResponseDTO
         );
         return ResponseEntity.created(url).body(response);
+    }
+
+    @DeleteMapping("/{id}")
+    @Transactional
+    public ResponseEntity<Void> deleteDepartmentById(@PathVariable Long id) {
+        departmentService.deleteDepartment(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/repository/IDepartmentRepository.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/repository/IDepartmentRepository.java
@@ -2,8 +2,19 @@ package com.example.skilllinkbackend.features.department.repository;
 
 import com.example.skilllinkbackend.features.department.model.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface IDepartmentRepository extends JpaRepository<Department, Long> {
+
+    @Query("""
+            SELECT d
+            FROM Department d
+            WHERE d.enabled = true
+            AND d.id = :id
+            """)
+    Optional<Department> findById(Long id);
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/service/DepartmentService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/service/DepartmentService.java
@@ -1,5 +1,6 @@
 package com.example.skilllinkbackend.features.department.service;
 
+import com.example.skilllinkbackend.config.exceptions.NotFoundException;
 import com.example.skilllinkbackend.features.department.dto.DepartmentRegisterDTO;
 import com.example.skilllinkbackend.features.department.dto.DepartmentResponseDTO;
 import com.example.skilllinkbackend.features.department.model.Department;
@@ -19,5 +20,12 @@ public class DepartmentService implements IDepartmentService {
     public DepartmentResponseDTO createDepartment(DepartmentRegisterDTO departmentDTO) {
         Department department = new Department(departmentDTO);
         return new DepartmentResponseDTO(departmentRepository.save(department));
+    }
+
+    @Override
+    public void deleteDepartment(Long id) {
+        Department department = departmentRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Departamento no encontrado"));
+        department.deactive();
     }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/service/IDepartmentService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/service/IDepartmentService.java
@@ -5,4 +5,6 @@ import com.example.skilllinkbackend.features.department.dto.DepartmentResponseDT
 
 public interface IDepartmentService {
     DepartmentResponseDTO createDepartment(DepartmentRegisterDTO departmentDTO);
+
+    void deleteDepartment(Long id);
 }


### PR DESCRIPTION
## 🗑️ Eliminar departamento por ID (solo ADMIN)

### 📌 Descripción

Este Pull Request implementa un nuevo **endpoint DELETE** que permite eliminar un departamento a partir de su identificador. Esta acción está restringida a usuarios con rol `ADMIN` y solo se permite si el departamento se encuentra habilitado (`enabled = true`).

### 📂 Archivos modificados

- `DepartmentController.java`: Se añadió el endpoint `DELETE /api/departments/{id}` con restricción de acceso para usuarios con rol `ADMIN`.
- `IDepartmentRepository.java`: Se agregó el método necesario para consultar o eliminar departamentos habilitados.
- `DepartmentService.java`: Se implementó la lógica para validar que el departamento exista, esté habilitado y luego proceder con la eliminación.
- `IDepartmentService.java`: Se definió la firma del nuevo método de eliminación.

### 🔐 Seguridad

- Requiere autenticación.
- Solo los usuarios con el rol `ADMIN` pueden realizar la operación.

### ✅ Reglas de negocio

- Solo se eliminan departamentos con `enabled = true`.
- Si el departamento no existe o no está habilitado, se lanza una excepción con código `404 Not Found`.
- La eliminación puede ser lógica o física según la estrategia definida (en este PR se asume eliminación lógica a menos que se indique lo contrario).

### 🧪 Testing

Se recomienda probar:
- Eliminación exitosa de un departamento habilitado.
- Intento de eliminación de un departamento no habilitado o inexistente.
- Rechazo de la operación si el usuario no tiene rol `ADMIN`.
