### PR TITLE
feat(department): get all

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
@@ -4,9 +4,13 @@ import com.example.skilllinkbackend.config.responses.DataResponse;
 import com.example.skilllinkbackend.features.department.dto.DepartmentRegisterDTO;
 import com.example.skilllinkbackend.features.department.dto.DepartmentResponseDTO;
 import com.example.skilllinkbackend.features.department.service.IDepartmentService;
+import com.example.skilllinkbackend.shared.util.PaginationResponseBuilder;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/departments")
@@ -47,5 +52,11 @@ public class DepartmentController {
     public ResponseEntity<Void> deleteDepartmentById(@PathVariable Long id) {
         departmentService.deleteDepartment(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public Map<String, Object> findAllDepartment(@PageableDefault(size = 10, sort = "code") Pageable pagination) {
+        Page<DepartmentResponseDTO> deparmentPage = departmentService.findAllDepartment(pagination);
+        return PaginationResponseBuilder.build(deparmentPage);
     }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/repository/IDepartmentRepository.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/repository/IDepartmentRepository.java
@@ -1,6 +1,8 @@
 package com.example.skilllinkbackend.features.department.repository;
 
 import com.example.skilllinkbackend.features.department.model.Department;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -17,4 +19,11 @@ public interface IDepartmentRepository extends JpaRepository<Department, Long> {
             AND d.id = :id
             """)
     Optional<Department> findById(Long id);
+
+    @Query("""
+            SELECT d
+            FROM Department d
+            WHERE d.enabled = true
+            """)
+    Page<Department> findAllDepartment(Pageable pagination);
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/service/DepartmentService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/service/DepartmentService.java
@@ -5,6 +5,8 @@ import com.example.skilllinkbackend.features.department.dto.DepartmentRegisterDT
 import com.example.skilllinkbackend.features.department.dto.DepartmentResponseDTO;
 import com.example.skilllinkbackend.features.department.model.Department;
 import com.example.skilllinkbackend.features.department.repository.IDepartmentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -27,5 +29,10 @@ public class DepartmentService implements IDepartmentService {
         Department department = departmentRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("Departamento no encontrado"));
         department.deactive();
+    }
+
+    @Override
+    public Page<DepartmentResponseDTO> findAllDepartment(Pageable pagination) {
+        return departmentRepository.findAllDepartment(pagination).map(DepartmentResponseDTO::new);
     }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/service/IDepartmentService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/service/IDepartmentService.java
@@ -2,9 +2,13 @@ package com.example.skilllinkbackend.features.department.service;
 
 import com.example.skilllinkbackend.features.department.dto.DepartmentRegisterDTO;
 import com.example.skilllinkbackend.features.department.dto.DepartmentResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface IDepartmentService {
     DepartmentResponseDTO createDepartment(DepartmentRegisterDTO departmentDTO);
 
     void deleteDepartment(Long id);
+
+    Page<DepartmentResponseDTO> findAllDepartment(Pageable pagination);
 }


### PR DESCRIPTION
## 📄 Listar departamentos habilitados (paginación y orden)

### 📌 Descripción

Este Pull Request agrega un nuevo **endpoint GET** que permite obtener todos los departamentos con `enabled = true`. Los resultados son retornados en formato paginado, con un tamaño de página por defecto de **10 elementos**, y **ordenados por el atributo `code`** de forma ascendente.

### 📂 Archivos modificados

- `DepartmentController.java`: Se agregó el endpoint `GET /api/departments` con soporte para paginación.
- `IDepartmentRepository.java`: Se añadió un método personalizado para consultar departamentos habilitados con paginación y orden.
- `DepartmentService.java`: Se implementó la lógica para obtener los datos de forma paginada y ordenada.
- `IDepartmentService.java`: Se declaró la nueva operación de lectura.

### 📦 Comportamiento

- Se retorna un objeto `Page<DepartmentResponseDTO>` con un máximo de 10 resultados por página.
- Solo se incluyen departamentos cuyo campo `enabled` sea `true`.
- El orden predeterminado es ascendente por el atributo `code`.
- El cliente puede navegar por páginas utilizando parámetros estándar (`page` y `size` si se habilita flexibilidad futura).

### ✅ Reglas

- Solo se muestran departamentos activos.
- El tamaño de página por defecto es `10` (puede hacerse configurable si se requiere más adelante).

### 🧪 Testing

Se recomienda verificar:
- Respuesta paginada correctamente estructurada.
- Que solo se incluyan departamentos con `enabled = true`.
- Orden correcto por `code` ascendente.
- Navegación entre páginas sin errores.
