### PR TITLE
feat(department): get by id

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
@@ -59,4 +59,9 @@ public class DepartmentController {
         Page<DepartmentResponseDTO> deparmentPage = departmentService.findAllDepartment(pagination);
         return PaginationResponseBuilder.build(deparmentPage);
     }
+
+    @GetMapping("/{id}")
+    public DepartmentResponseDTO getDepartmentById(@PathVariable Long id) {
+        return departmentService.getDepartmentById(id);
+    }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/service/DepartmentService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/service/DepartmentService.java
@@ -35,4 +35,11 @@ public class DepartmentService implements IDepartmentService {
     public Page<DepartmentResponseDTO> findAllDepartment(Pageable pagination) {
         return departmentRepository.findAllDepartment(pagination).map(DepartmentResponseDTO::new);
     }
+
+    @Override
+    public DepartmentResponseDTO getDepartmentById(Long id) {
+        Department department = departmentRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Departamento no encontrado"));
+        return new DepartmentResponseDTO(department);
+    }
 }

--- a/src/main/java/com/example/skilllinkbackend/features/department/service/IDepartmentService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/service/IDepartmentService.java
@@ -11,4 +11,6 @@ public interface IDepartmentService {
     void deleteDepartment(Long id);
 
     Page<DepartmentResponseDTO> findAllDepartment(Pageable pagination);
+
+    DepartmentResponseDTO getDepartmentById(Long id);
 }


### PR DESCRIPTION
## 🔍 Obtener departamento por ID (solo si está habilitado)

### 📌 Descripción

Este Pull Request agrega un nuevo **endpoint GET** que permite obtener los datos de un departamento específico a través de su identificador (`id`), siempre y cuando el departamento tenga `enabled = true`.

### 📂 Archivos modificados

- `DepartmentController.java`: Se agregó el endpoint `GET /api/departments/{id}` para recuperar un departamento por su ID, con restricción de acceso a usuarios con roles `ADMIN` y `RECEPTION`.
- `DepartmentService.java`: Se implementó la lógica para validar que el departamento exista y esté habilitado.
- `IDepartmentService.java`: Se declaró la nueva operación de consulta por ID.

### ✅ Reglas de negocio

- El departamento debe existir y tener el campo `enabled = true`.
- Si no se encuentra o no está habilitado, se retorna un error `404 Not Found`.
- El resultado se devuelve en un `DepartmentResponseDTO` con los datos estructurados del departamento.

### 🔐 Seguridad

- **Acceso restringido a usuarios con roles `ADMIN` y `RECEPTION`.**
- Cualquier otro rol recibirá una respuesta `403 Forbidden`.

### 🧪 Testing

Se recomienda verificar los siguientes escenarios:
- Consulta exitosa de un departamento habilitado por un usuario con rol `ADMIN` o `RECEPTION`.
- Intento de consulta por parte de un usuario con rol no autorizado (debe retornar `403`).
- Consulta de un departamento deshabilitado o inexistente (debe retornar `404`).
