### PR TITLE
docs(department): add SpringDoc annotations to controller and dtos

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
@@ -6,7 +6,12 @@ import com.example.skilllinkbackend.features.department.dto.DepartmentResponseDT
 import com.example.skilllinkbackend.features.department.dto.DepartmentUpdateDTO;
 import com.example.skilllinkbackend.features.department.service.IDepartmentService;
 import com.example.skilllinkbackend.shared.util.PaginationResponseBuilder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -25,6 +30,7 @@ import java.util.Map;
 @RequestMapping("/departments")
 @SecurityRequirement(name = "bearer-key")
 @PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Departamentos", description = "Operaciones relacionadas con la gestión de departamentos")
 public class DepartmentController {
 
     private final IDepartmentService departmentService;
@@ -33,6 +39,14 @@ public class DepartmentController {
         this.departmentService = departmentService;
     }
 
+    @Operation(
+            summary = "Crear un nuevo departamento",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Departamento creado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     public ResponseEntity<DataResponse<DepartmentResponseDTO>> createDepartment(
@@ -48,6 +62,14 @@ public class DepartmentController {
         return ResponseEntity.created(url).body(response);
     }
 
+    @Operation(
+            summary = "Eliminar un departamento por ID",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Departamento eliminado exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Departamento no encontrado", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteDepartmentById(@PathVariable Long id) {
@@ -55,6 +77,18 @@ public class DepartmentController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(
+            summary = "Listar departamentos con paginación",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo para ordenar (ej: code,asc)", example = "code,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de departamentos")
+            }
+    )
     @PreAuthorize("hasAnyRole('ADMIN', 'RECEPTION')")
     @GetMapping
     public Map<String, Object> findAllDepartment(@PageableDefault(size = 10, sort = "code") Pageable pagination) {
@@ -62,12 +96,29 @@ public class DepartmentController {
         return PaginationResponseBuilder.build(deparmentPage);
     }
 
+    @Operation(
+            summary = "Obtener un departamento por su ID",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Departamento encontrado"),
+                    @ApiResponse(responseCode = "404", description = "Departamento no encontrado", content = @Content)
+            }
+    )
     @PreAuthorize("hasAnyRole('ADMIN', 'RECEPTION')")
     @GetMapping("/{id}")
     public DepartmentResponseDTO getDepartmentById(@PathVariable Long id) {
         return departmentService.getDepartmentById(id);
     }
 
+    @Operation(
+            summary = "Actualizar un departamento existente",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Departamento actualizado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Departamento no encontrado", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public DepartmentResponseDTO updateDepartment(

--- a/src/main/java/com/example/skilllinkbackend/features/department/dto/DepartmentUpdateDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/dto/DepartmentUpdateDTO.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
-@Schema(description = "Datos necesarios para crear un departamento")
+@Schema(description = "Datos necesarios para editar un departamento")
 public record DepartmentUpdateDTO(
         @Schema(description = "ID del departamento", example = "1")
         @NotNull(message = "El id del departamento no puede ser nulo")


### PR DESCRIPTION
## 📝 Documentación con SpringDoc para el módulo de departamentos

### 📌 Descripción

Este Pull Request mejora la documentación de la API del módulo de departamentos mediante la incorporación de anotaciones de **SpringDoc OpenAPI**. Estas anotaciones permiten generar una documentación más clara, estructurada y navegable en herramientas como Swagger UI.

### 📂 Archivos modificados

- `DepartmentController.java`: Se agregaron anotaciones como `@Operation`, `@ApiResponse`, `@Parameter` y `@Tag` para documentar los endpoints disponibles.
- `DepartmentUpdateDTO.java`: Se utilizaron anotaciones `@Schema` en los campos del DTO para describir su propósito, formato y restricciones.

### ✅ Beneficios

- Mejora la experiencia de desarrollo y consumo de la API desde el frontend u otros servicios.
- Facilita la comprensión de los contratos de entrada y salida.
- Permite visualizar y probar los endpoints de manera interactiva mediante Swagger UI.

### 🔐 Seguridad

- No se modificó la lógica de autenticación ni autorización. Este cambio es puramente **documental**.

### 🧪 Verificación

- Visualización de los endpoints en Swagger UI con sus respectivas descripciones.
- Verificación de la correcta documentación de los campos del DTO.
