### PR TITLE
docs(booking): add SpringDoc annotations to controller and dtos

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/features/booking/controller/BookingController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/booking/controller/BookingController.java
@@ -7,7 +7,12 @@ import com.example.skilllinkbackend.features.booking.dto.BookingUpdateDTO;
 import com.example.skilllinkbackend.features.booking.model.ReservationStatus;
 import com.example.skilllinkbackend.features.booking.service.IBookingService;
 import com.example.skilllinkbackend.shared.util.PaginationResponseBuilder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,10 +36,19 @@ import java.util.Map;
 @RequiredArgsConstructor
 @SecurityRequirement(name = "bearer-key")
 @PreAuthorize("hasAnyRole('ADMIN', 'RECEPTION')")
+@Tag(name = "Reservas", description = "Operaciones relacionadas con la gestión de reservas")
 public class BookingController {
 
     private final IBookingService bookingService;
 
+    @Operation(
+            summary = "Crear una nueva reserva",
+            description = "Solo accesible por usuarios con rol ADMIN y RECEPTION",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Reserva creada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     public ResponseEntity<DataResponse<BookingResponseDTO>> createBooking(
@@ -51,6 +65,14 @@ public class BookingController {
         return ResponseEntity.created(url).body(response);
     }
 
+    @Operation(
+            summary = "Eliminar una reserva por ID",
+            description = "Solo accesible por usuarios con rol ADMIN y RECEPTION",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Reserva eliminada exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Reserva no encontrada", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteBooking(@PathVariable Long id) {
@@ -58,6 +80,18 @@ public class BookingController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(
+            summary = "Listar reservas con paginación",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo para ordenar (ej: createdAt,asc)", example = "createdAt,desc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de reservas")
+            }
+    )
     @GetMapping
     public Map<String, Object> findAllBooking(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
@@ -80,11 +114,28 @@ public class BookingController {
         return PaginationResponseBuilder.build(bookingPage);
     }
 
+    @Operation(
+            summary = "Obtener una reserva por su ID",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Reserva encontrada"),
+                    @ApiResponse(responseCode = "404", description = "Reserva no encontrada", content = @Content)
+            }
+    )
     @GetMapping("/{id}")
     public BookingResponseDTO findById(@PathVariable Long id) {
         return bookingService.findById(id);
     }
 
+    @Operation(
+            summary = "Actualizar una reserva existente",
+            description = "Solo accesible por usuarios con rol ADMIN o RECEPTION",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Reserva actualizada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Reserva no encontrada", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public BookingResponseDTO updateBooking(

--- a/src/main/java/com/example/skilllinkbackend/features/booking/dto/BookingRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/booking/dto/BookingRegisterDTO.java
@@ -1,6 +1,7 @@
 package com.example.skilllinkbackend.features.booking.dto;
 
 import com.example.skilllinkbackend.features.bookingitem.dto.BookingItemRegisterDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -8,20 +9,27 @@ import jakarta.validation.constraints.Size;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+@Schema(description = "Datos necesarios para crear una reserva")
 public record BookingRegisterDTO(
 
+        @Schema(description = "ID del huésped", example = "1")
         @NotNull(message = "El ID del huésped no puede ser nulo")
         Long guestId,
 
+        @Schema(description = "ID del recepcionista quien crea la reserva", example = "1")
         @NotNull(message = "El ID del recepcionista no puede ser nulo")
         Long receptionistId,
 
+        @Schema(description = "Fecha de inicio de la reserva", example = "2025-07-28T11:00:00Z")
         @NotNull(message = "La fecha de inicio no puede ser nulo")
         OffsetDateTime checkIn,
 
+        @Schema(description = "Fecha final de la reserva", example = "2025-08-13T11:00:00-05:00")
         @NotNull(message = "La fecha de salida no puede ser nulo")
         OffsetDateTime checkOut,
 
+        @Schema(description = "Lista de items de la reserva",
+                example = "[{\"accommodationId\": 101, \"price\": 150.00}]")
         @NotNull(message = "La lista de items es requerido")
         @Size(min = 1, message = "Se requiere al menos un elemento de reserva")
         @Valid

--- a/src/main/java/com/example/skilllinkbackend/features/booking/dto/BookingUpdateDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/booking/dto/BookingUpdateDTO.java
@@ -2,6 +2,7 @@ package com.example.skilllinkbackend.features.booking.dto;
 
 import com.example.skilllinkbackend.features.booking.model.ReservationStatus;
 import com.example.skilllinkbackend.features.bookingitem.dto.BookingItemUpdateDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -9,26 +10,35 @@ import jakarta.validation.constraints.Size;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+@Schema(description = "Datos necesarios para editar una reserva")
 public record BookingUpdateDTO(
 
+        @Schema(description = "ID de la reserva", example = "1")
         @NotNull(message = "El ID de la reserva no puede ser nulo")
         Long id,
 
+        @Schema(description = "ID del huésped", example = "1")
         @NotNull(message = "El ID del huésped no puede ser nulo")
         Long guestId,
 
+        @Schema(description = "ID del recepcionista", example = "1")
         @NotNull(message = "El ID del recepcionista no puede ser nulo")
         Long receptionistId,
 
+        @Schema(description = "Fecha de inicio de la reserva", example = "2025-07-28T11:00:00Z")
         @NotNull(message = "La fecha de inicio no puede ser nulo")
         OffsetDateTime checkIn,
 
+        @Schema(description = "Fecha final de la reserva", example = "2025-08-13T11:00:00-05:00")
         @NotNull(message = "La fecha de salida no puede ser nulo")
         OffsetDateTime checkOut,
 
+        @Schema(description = "Estado de la reserva", example = "RESERVED")
         @NotNull(message = "El estado de la reserva no puede ser nulo")
         ReservationStatus status,
 
+        @Schema(description = "Lista de items de la reserva",
+                example = "[{\"accommodationId\": 101, \"price\": 150.00}]")
         @NotNull(message = "La lista de items es requerido")
         @Size(min = 1, message = "Se requiere al menos un elemento de reserva")
         @Valid

--- a/src/main/java/com/example/skilllinkbackend/features/bookingitem/dto/BookingItemRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/bookingitem/dto/BookingItemRegisterDTO.java
@@ -1,14 +1,17 @@
 package com.example.skilllinkbackend.features.bookingitem.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
 public record BookingItemRegisterDTO(
+        @Schema(example = "101", description = "ID del alojamiento")
         @NotNull(message = "El ID del alojamiento es necesario")
         Long accommodationId,
 
+        @Schema(example = "150.00", description = "Precio del alojamiento por el tiempo de reserva")
         @NotNull(message = "El precio del alojamiento no puede ser nulo")
         @DecimalMin("0.0")
         BigDecimal price

--- a/src/main/java/com/example/skilllinkbackend/features/bookingitem/dto/BookingItemUpdateDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/bookingitem/dto/BookingItemUpdateDTO.java
@@ -1,17 +1,21 @@
 package com.example.skilllinkbackend.features.bookingitem.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
 public record BookingItemUpdateDTO(
+        @Schema(example = "1", description = "ID de la reserva")
         @NotNull(message = "El ID del booking item no puede ser nulo")
         Long id,
 
+        @Schema(example = "101", description = "ID del alojamiento")
         @NotNull(message = "El ID del alojamiento es necesario")
         Long accommodationId,
 
+        @Schema(example = "150.00", description = "Precio del alojamiento por el tiempo de reserva")
         @NotNull(message = "El precio del alojamiento no puede ser nulo")
         @DecimalMin("0.0")
         BigDecimal price


### PR DESCRIPTION
## ✨ Descripción del PR

Este PR agrega anotaciones de **SpringDoc OpenAPI** (`@Operation`, `@Schema`, etc.) a los controladores y DTOs relacionados con el módulo de **Booking**, con el fin de mejorar la documentación generada automáticamente para la API.

### ✅ Cambios realizados

Se añadieron descripciones y ejemplos a los siguientes archivos:

- `BookingController.java`  
  - Anotaciones `@Operation` y `@Parameter` para describir los endpoints de Booking.

- `BookingRegisterDTO.java`  
  - Descripciones y ejemplos para los campos, incluyendo la lista de ítems de reserva (`bookingItems`).

- `BookingUpdateDTO.java`  
  - Anotaciones similares para facilitar la comprensión de los datos requeridos al actualizar una reserva.

- `BookingItemRegisterDTO.java`  
  - Documentación de los campos `accommodationId` y `price`.

- `BookingItemUpdateDTO.java`  
  - Ejemplos y descripciones para los campos de actualización de ítems de reserva.

### 🧠 Motivación

Esta mejora permite:

- Una experiencia más clara y completa en la interfaz de Swagger UI.
- Mejor comunicación de las estructuras esperadas al consumir la API.
- Facilita la validación y pruebas manuales a través del explorador interactivo.
