### PR TITLE
chore(api): add /api/v1 prefix to all endpoints

### DIFF
--- a/src/main/java/com/example/skilllinkbackend/config/security/SecurityConfigurations.java
+++ b/src/main/java/com/example/skilllinkbackend/config/security/SecurityConfigurations.java
@@ -35,8 +35,8 @@ public class SecurityConfigurations {
         http.csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(req -> req
-                        .requestMatchers(HttpMethod.POST, "/login").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/users/register").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users/register").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/",
                                 "/swagger-ui/**",

--- a/src/main/java/com/example/skilllinkbackend/features/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/auth/controller/AuthenticationController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/login")
+@RequestMapping("/api/v1/login")
 @Tag(name = "Autenticación", description = "Inicio de sesión de usuarios y generación de token JWT")
 public class AuthenticationController {
 

--- a/src/main/java/com/example/skilllinkbackend/features/auth/service/TokenService.java
+++ b/src/main/java/com/example/skilllinkbackend/features/auth/service/TokenService.java
@@ -23,7 +23,7 @@ public class TokenService {
         try {
             Algorithm algorithm =  Algorithm.HMAC256(apiSecret);
             return JWT.create()
-                    .withIssuer("Skill Link")
+                    .withIssuer("Shepard")
                     .withSubject(user.getUsername())
                     .withClaim("id", user.getUserId())
                     .withExpiresAt(generateExpirationDate())

--- a/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/department/controller/DepartmentController.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/departments")
+@RequestMapping("/api/v1/departments")
 @SecurityRequirement(name = "bearer-key")
 @PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Departamentos", description = "Operaciones relacionadas con la gestión de departamentos")

--- a/src/main/java/com/example/skilllinkbackend/features/room/controller/RoomController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/room/controller/RoomController.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/rooms")
+@RequestMapping("/api/v1/rooms")
 @SecurityRequirement(name = "bearer-key")
 @PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Habitaciones", description = "Operaciones relacionadas con la gestión de habitaciones")

--- a/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/roomtype/controller/RoomTypeController.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/room-types")
+@RequestMapping("/api/v1/room-types")
 @AllArgsConstructor
 @SecurityRequirement(name = "bearer-key")
 @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/example/skilllinkbackend/features/usuario/controller/UserController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/usuario/controller/UserController.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/v1/users")
 @Tag(name = "Usuarios", description = "Operaciones relacionadas con los usuarios del sistema")
 public class UserController {
 


### PR DESCRIPTION
## 🔄 Descripción  
Este PR actualiza la estructura de rutas de la API para agregar el prefijo común `/api/v1` a todos los endpoints, asegurando consistencia y versionado claro en la plataforma.  

## 📂 Archivos modificados  
- **Configuración de seguridad**  
  - `SecurityConfigurations.java`: Ajuste de reglas de seguridad para contemplar el nuevo prefijo `/api/v1`.  

- **Controladores**  
  - `AuthenticationController.java`  
  - `DepartmentController.java`  
  - `RoomController.java`  
  - `RoomTypeController.java`  
  - `UserController.java`  
  → Actualización de las rutas base con el nuevo prefijo `/api/v1`.  

- **Servicios**  
  - `TokenService.java`: Ajuste para que la generación y validación de tokens considere las rutas actualizadas.  

## 🎯 Objetivo  
- Implementar versionado de la API mediante el prefijo `/api/v1`.  
- Mejorar la organización y escalabilidad de la API para futuras versiones (`/api/v2`, etc.).  
- Mantener consistencia entre todos los controladores.  

## ✅ Resultados esperados  
- Todas las rutas públicas y protegidas comienzan ahora con `/api/v1`.  
- La configuración de seguridad sigue funcionando correctamente con el nuevo esquema de rutas.  
